### PR TITLE
Connect to base iNZight interact button (iNZightVIT/iNZight#101)

### DIFF
--- a/R/iNZightMaps2.R
+++ b/R/iNZightMaps2.R
@@ -778,8 +778,9 @@ iNZightMap2Mod <- setRefClass(
             dev.flush()
             gdkWindowSetCursor(getToolkitWidget(GUI$win)$getWindow(), NULL)
 
-            invisible(map.plot)
             plotObject <<- map.plot
+            enabled(GUI$plotToolbar$exportplotBtn) <<- iNZightPlots::can.interact(map.plot)
+            invisible(map.plot)
         },
 
         ## After the map object has been constructed, initialize the interface for the Maps module (sidebar)
@@ -1611,16 +1612,18 @@ iNZightMap2Mod <- setRefClass(
                                       visible(GUI$gp1) <<- TRUE
                                   })
 
-            exportButton <- iNZight:::gimagebutton(stock.id = "zoom-in",
-                                         tooltip = "Export interactive map", size = "button")
+            # exportButton <- iNZight:::gimagebutton(stock.id = "zoom-in",
+            #                              tooltip = "Export interactive map", size = "button")
 
-            addHandlerClicked(exportButton, function(h, ...) {
-                browseURL(iNZightPlots::exportHTML(x = plotObject,
-                                         mapObj = combinedData,
-                                         file = tempfile(fileext = ".html")))
-            })
+            # addHandlerClicked(exportButton, function(h, ...) {
+            # })
 
-            GUI$plotToolbar$update(NULL, refresh = "updatePlot", extra = list(exportButton))
+            GUI$plotToolbar$update("export", refresh = "updatePlot", 
+                                export = function() {
+                                    browseURL(iNZightPlots::exportHTML(x = plotObject,
+                                        mapObj = combinedData,
+                                        file = tempfile(fileext = ".html")))
+                                })
 
             visible(mainGrp) <<- TRUE
             updateOptions()


### PR DESCRIPTION
Modified export to use the new button supplied by base iNZight.

* Line 783 - the invisible(map.plot) was initially _before_ assignment of `plotObject`; I've switched so the invisible return is last so it actually happens
* Line 1621 - since several specific things need to be passed, easiest for each module to just specify the function manually (or, by default, iNZight will attempt to use the refresh function without any additional arguments)

I also noticed that in the exported plot, all of the labels are completely messed up. 

Finally, to test, you'll need ~iNZight@feature/interact-button~ iNZight@dev and iNZightPlots@dev.