### PR TITLE
Change default continuous palette for maps to inferno

### DIFF
--- a/R/iNZightMaps.R
+++ b/R/iNZightMaps.R
@@ -403,7 +403,7 @@ iNZightMapMod <- setRefClass(
               ii.colour <- ii.colour + 1
 
               lbl.palette <- glabel("Palette:")
-              combobox.paletteCont <- gcombobox(names(colourPalettes$cont))
+              combobox.paletteCont <- gcombobox(names(colourPalettes$cont), selected = 4)
               combobox.paletteCat <- gcombobox(names(colourPalettes$cat))
               
               tbl.colour[ii.colour, 1:2, anchor = c(1, 0), expand = TRUE] <- lbl.palette


### PR DESCRIPTION
This just changes the default to inferno as viridis is too similar to the background colours with these new Stamen maps. 